### PR TITLE
Promoting Brawl Stars to Main Wiki

### DIFF
--- a/includes/wikis.php
+++ b/includes/wikis.php
@@ -9,6 +9,12 @@ $protocol = 'https://';
 $baseurl = $protocol . 'liquipedia.net';
 
 $wikis = [
+	'brawlstars' => [
+		'name' => 'Brawl Stars',
+		'theme-light' => '#3a5ba9',
+		'theme-dark' => '#b0c5ff',
+		'api' => $baseurl . '/brawlstars/api.php',
+	],
 	'dota2' => [
 		'name' => 'Dota 2',
 		'theme-light' => '#bc111d',
@@ -154,12 +160,6 @@ $alphawikis = [
 		'theme-light' => '#3a5ba9',
 		'theme-dark' => '#b0c5ff',
 		'api' => $baseurl . '/callofduty/api.php',
-	],
-	'brawlstars' => [
-		'name' => 'Brawl Stars',
-		'theme-light' => '#3a5ba9',
-		'theme-dark' => '#b0c5ff',
-		'api' => $baseurl . '/brawlstars/api.php',
 	],
 	'trackmania' => [
 		'name' => 'Trackmania',

--- a/includes/wikis.php
+++ b/includes/wikis.php
@@ -14,6 +14,7 @@ $wikis = [
 		'theme-light' => '#3a5ba9',
 		'theme-dark' => '#b0c5ff',
 		'api' => $baseurl . '/brawlstars/api.php',
+		'new' => true,
 	],
 	'dota2' => [
 		'name' => 'Dota 2',


### PR DESCRIPTION
moving Brawl Stars from Alpha to a Main wiki, per meeting with Ricci earlier today (meeting happens around 2PM EU today)