### PR TITLE
make sure the dark theme toggle functions cannot indefinitely loop rough events

### DIFF
--- a/js/modules/theme.js
+++ b/js/modules/theme.js
@@ -23,17 +23,17 @@ export class Theme {
         this.setupEventListener();
     }
 
-    setDarkMode() {
+    setDarkMode( setLocalStorage = true ) {
         this.htmlElement.classList.remove( this.lightThemeClass );
         this.htmlElement.classList.add( this.darkThemeClass );
-        this.setLocalStorage();
+        this.setLocalStorage( 'true' );
         // this.setAriaPressed( 'true' );
     }
 
-    setLightMode() {
+    setLightMode( setLocalStorage = true ) {
         this.htmlElement.classList.remove( this.darkThemeClass );
         this.htmlElement.classList.add( this.lightThemeClass );
-        this.setLocalStorage();
+        this.setLocalStorage( null );
         // this.setAriaPressed( 'false' );
     }
 
@@ -45,8 +45,8 @@ export class Theme {
         }
     }
 
-    setLocalStorage() {
-        window.localStorage.setItem( this.darkModeStorageKey, this.darkModeActive.toString() );
+    setLocalStorage( value ) {
+        window.localStorage.setItem( this.darkModeStorageKey, value );
     }
 
     checkLocalStorage() {
@@ -58,9 +58,9 @@ export class Theme {
             if ( event.key === this.darkModeStorageKey ) {
                 this.darkModeActive = JSON.parse( event.newValue );
                 if ( event.newValue === 'true' ) {
-                    this.setDarkMode();
+                    this.setDarkMode( false );
                 } else {
-                    this.setLightMode();
+                    this.setLightMode( false );
                 }
             }
         } );


### PR DESCRIPTION
## Description

This disables writing to localStorage when the theme is changed by a localStorage event. This should be fine, as the value in localStorage should already have that value. As a result we avoid a situation where we have localStorage being written again and again which I suspect is causing the event handler to repeatedly fire.

## Related Issues

Closes https://gitlab.com/teamliquid-dev/liquipedia/web/issue-bucket/-/issues/25

## Checklist

- [ ] I have tested these changes locally
- [ ] I have added/modified tests (if applicable)
- [ ] I have updated the documentation if necessary