### PR TITLE
Add Chess and resize F1 back to non-wide

### DIFF
--- a/includes/wikis.php
+++ b/includes/wikis.php
@@ -160,8 +160,13 @@ $sportswikis = [
 		'theme-light' => '#bc111d',
 		'theme-dark' => '#fad1d1',
 		'api' => $baseurl . '/formula1/api.php',
+	],
+	'chess' => [
+		'name' => 'Chess',
+		'theme-light' => '#7e5700',
+		'theme-dark' => '#fabc45',
+		'api' => $baseurl . '/chess/api.php',
 		'new' => true,
-		'class' => 'card__wide',
 	],
 ];
 $alphawikis = [


### PR DESCRIPTION
(At the time of this writing: Gitlab request will be up alongside this in moments)

- Add Chess to Sports wiki section, add a new tag for it
- Remove F1 wide card class, since you mention its wide because its just 1 wiki, remove its new tag
- Add Banner (the non wide size)

- _Logos for Chess will be up here by tomorrow, waiting for SVG conversion from iMarbot_
